### PR TITLE
Get registers list

### DIFF
--- a/nft-ns-admin/src/util.js
+++ b/nft-ns-admin/src/util.js
@@ -502,7 +502,7 @@ class Util {
       return domainNames
     } catch (error) {
       console.error('Error in getTLDNames: ', error)
-      console.log(`slpAddr: ${addr}`)
+      console.log(`BCH Addr: ${addr}`)
       throw error
     }
   }

--- a/nft-ns-admin/src/util.js
+++ b/nft-ns-admin/src/util.js
@@ -529,42 +529,6 @@ class Util {
       throw error
     }
   }
-
-  // Get biggest UTXO
-  // Returns the utxo with the biggest balance from an array of utxos.
-  async findBiggestUtxo (utxos) {
-    try {
-      let largestAmount = 0
-      let largestIndex = 0
-
-      for (var i = 0; i < utxos.length; i++) {
-        const thisUtxo = utxos[i]
-        // console.log(`thisUTXO: ${JSON.stringify(thisUtxo, null, 2)}`);
-
-        // Validate the UTXO data with the full node.
-        /* eslint-disable no-await-in-loop */
-        const txout = await bchjs.Blockchain.getTxOut(thisUtxo.tx_hash, thisUtxo.tx_pos)
-        /* eslint-enable no-await-in-loop */
-        if (txout === null) {
-          // If the UTXO has already been spent, the full node will respond with null.
-          console.log(
-            'Stale UTXO found. You may need to wait for the indexer to catch up.'
-          )
-          continue
-        }
-
-        if (thisUtxo.value > largestAmount) {
-          largestAmount = thisUtxo.value
-          largestIndex = i
-        }
-      }
-
-      return utxos[largestIndex]
-    } catch (error) {
-      console.error('Error in findBiggestUtxo: ', error)
-      throw error
-    }
-  }
 }
 
 module.exports = Util

--- a/nft-ns-query/README.md
+++ b/nft-ns-query/README.md
@@ -42,6 +42,7 @@ USAGE
 * [`nft-ns-query help [COMMAND]`](#nft-ns-query-help-command)
 * [`nft-ns-query address`](#nft-ns-query-address) - name to address resolve
 * [`nft-ns-query name`](#nft-ns-query-name) - address to name resolve
+* [`nft-ns-query registers`](#nft-ns-query-registers) - get list of TLD registers
 
 ## `nft-ns-query help [COMMAND]`
 
@@ -74,7 +75,7 @@ Information is retreived from the SLPDB tokens information.
 
 Provide full name to `-n|--name` option (`user.bch` - good, `user` - no).
 The provider NFT Group token ID can be specified. If no the default one will be used.
-Provider NFT Group token IDs can be seen in the Admin tool TLD list. 
+Provider NFT Group token IDs can be seen in the Admin tool TLD list.
 
 Some basic checks (TLD existance, user name existence etc.) are also implemented.
 
@@ -121,4 +122,30 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/name.js](https://github.com/zh/nft-ns/blob/v0.1.0/src/commands/name.js)_
+
+## `nft-ns-query registers`
+
+Get list of TLD registers
+
+Provide BCH address for the account, holding TLD addresses.
+Will generate JSON file in the config directory.
+
+Information is retreived from the address tokens UTXO information.
+
+```
+USAGE
+  $ ./bin/run registers
+  $ ./bin/run registers -b bitcoincash:qrjkt...
+
+OPTIONS
+  -b, --bch=bch  BCH address of the account with registers
+
+DESCRIPTION
+  ...
+  Provide BCH address for the account, holding TLD addresses.
+  Will generate JSON file in the config directory.
+```
+
+_See code: [src/commands/registers.js](https://github.com/zh/nft-ns/blob/v0.1.0/src/commands/registers.js)_
+
 <!-- commandsstop -->

--- a/nft-ns-query/src/commands/registers.js
+++ b/nft-ns-query/src/commands/registers.js
@@ -1,0 +1,26 @@
+const {cli} = require('cli-ux')
+const {Command, flags} = require('@oclif/command')
+const AppUtil = require('../util.js')
+const util = new AppUtil()
+
+class RegistersCommand extends Command {
+  async run() {
+    const {flags} = this.parse(RegistersCommand)
+    const bchAddress = flags.bch || 'bitcoincash:qqqmlvpdvcwtvkk60a28l77nj0d9h392cvxafe4hfe'
+    cli.action.start('Blockchain access')
+    await util.getTLDNames(bchAddress, this.config.configDir)
+    cli.action.stop()
+  }
+}
+
+RegistersCommand.description = `Get list of TLD registers
+...
+Provide BCH address for the account, holding TLD addresses.
+Will generate JSON file in the config directory.
+`
+
+RegistersCommand.flags = {
+  bch: flags.string({char: 'b', description: 'BCH address of the account with registers'})
+}
+
+module.exports = RegistersCommand

--- a/nft-ns-query/test/commands/registers.test.js
+++ b/nft-ns-query/test/commands/registers.test.js
@@ -1,0 +1,17 @@
+const {expect, test} = require('@oclif/test')
+
+describe('registers', () => {
+  test
+  .stdout()
+  .command(['registers'])
+  .it('runs hello', ctx => {
+    expect(ctx.stdout).to.contain('hello world')
+  })
+
+  test
+  .stdout()
+  .command(['registers', '--name', 'jeff'])
+  .it('runs hello --name jeff', ctx => {
+    expect(ctx.stdout).to.contain('hello jeff')
+  })
+})


### PR DESCRIPTION
JSON file with TLD registers tokenIDs is retrieved from the BCH account, holding them (holding the group NFTs)